### PR TITLE
[fix_smurf_remote] The remote for tools smurf is now in github

### DIFF
--- a/source.yml
+++ b/source.yml
@@ -42,7 +42,7 @@ version_control:
 
 # Special case for tools/smurf
     - tools/smurf:
-        spacegit: rock-cpp/$PACKAGE_BASENAME
+        github: rock-cpp/$PACKAGE_BASENAME
         branch: master
     
     - external/ogdf:


### PR DESCRIPTION
This should have triggered errors long ago. I wonder why it didn't