### PR TITLE
Switch to using official debian packages of gdal for recent distributions

### DIFF
--- a/envire.osdeps
+++ b/envire.osdeps
@@ -1,0 +1,7 @@
+envire/gdal:
+    ubuntu:
+        '16.04': nonexistent
+        default: libgdal-dev
+    debian:
+        'jessie,stretch': nonexistent
+        default: libgdal-dev


### PR DESCRIPTION
There seems to be no need for a custom envire/gdal since gdal >=2.2  already includes the required patch to install gnm headers.
Note that while envire/gdal and envire/envire_gis are considered deprecated based on the information in the envire wiki, envire/envire_maps still depends on these packages.

Current setup triggers the follower linker error when building envire/envire_maps:
```
  [100%] Built target envire_maps-viz
    CMakeFiles/test_suite.dir/test_ElevationRaster.cpp.o:(.data.rel.ro._ZTVN6envire3gis12RasterPluginIN4maps4grid12ElevationMapEEE[_ZTVN6envire3gis12RasterPluginIN4maps4grid12ElevationMapEEE]+0x70): undefined reference to `GDALRasterBand::IGetDataCoverageStatus(int, int, int, int, int, double*)'
    CMakeFiles/test_suite.dir/test_ElevationRaster.cpp.o:(.data.rel.ro._ZTVN6envire3gis16RasterPluginBandIN4maps4grid12ElevationMapEEE[_ZTVN6envire3gis16RasterPluginBandIN4maps4grid12ElevationMapEEE]+0x70): undefined reference to `GDALRasterBand::IGetDataCoverageStatus(int, int, int, int, int, double*)'
    collect2: error: ld returned 1 exit status
```