### PR TITLE
Adds an override to avoid Octovis to use QT5 so that envire_octomap c…

### DIFF
--- a/overrides.rb
+++ b/overrides.rb
@@ -1,0 +1,1 @@
+Autobuild::Package['slam/octomap'].define  "OCTOVIS_QT5", "OFF"


### PR DESCRIPTION
…an build on ubuntu 18.05